### PR TITLE
restore workflow_type WorkflowExecution's attribute

### DIFF
--- a/swf/models/workflow.py
+++ b/swf/models/workflow.py
@@ -313,6 +313,7 @@ class WorkflowExecution(BaseModel):
         'workflow_id',
         'run_id',
         'status',
+        'workflow_type',
         'task_list',
         'child_policy',
         'close_status',
@@ -322,17 +323,18 @@ class WorkflowExecution(BaseModel):
         'decision_tasks_timeout',
     ]
 
-    def __init__(self, domain,
-                 workflow_id, run_id=None,
-                 status=STATUS_OPEN, task_list=None,
-                 child_policy=None, close_status=None,
-                 execution_timeout=None, input=None,
-                 tag_list=None, decision_tasks_timeout=None,
+    def __init__(self, domain, workflow_id, run_id=None,
+                 status=STATUS_OPEN, workflow_type=None,
+                 task_list=None, child_policy=None,
+                 close_status=None, execution_timeout=None,
+                 input=None, tag_list=None,
+                 decision_tasks_timeout=None,
                  *args, **kwargs):
         self.domain = domain
         self.workflow_id = workflow_id
         self.run_id = run_id
         self.status = status
+        self.workflow_type = workflow_type
         self.task_list = task_list
         self.child_policy = child_policy
         self.close_status = close_status

--- a/swf/querysets/workflow.py
+++ b/swf/querysets/workflow.py
@@ -430,10 +430,17 @@ class WorkflowExecutionQuerySet(BaseWorkflowQuerySet):
         )
 
     def to_WorkflowExecution(self, domain, execution_info, **kwargs):
+        workflow_type = WorkflowType(
+            self.domain,
+            execution_info['workflowType']['name'],
+            execution_info['workflowType']['version']
+        )
+
         return WorkflowExecution(
             domain,
             get_subkey(execution_info, ['execution', 'workflowId']),  # workflow_id
             run_id=get_subkey(execution_info, ['execution', 'runId']),
+            workflow_type=workflow_type,
             status=execution_info.get('executionStatus'),
             close_status=execution_info.get('closeStatus'),
             tag_list=execution_info.get('tagList'),


### PR DESCRIPTION
In order to enhance and boost metrics collection,
WorkflowExecutionQuerySet will return WorkflowExecutions
which workflow_type attribute is set. New http request has
been avoided.
