### PR TITLE
record marker failes because markerName is not added to recordMarkerDecisionAttributes

### DIFF
--- a/swf/models/decision/marker.py
+++ b/swf/models/decision/marker.py
@@ -22,5 +22,7 @@ class MarkerDecision(Decision):
         :type   details: str
         """
 
-        self['markerName'] = name
-        self.update_attributes({'details': details})
+        self.update_attributes({
+            'markerName': name,
+            'details': details
+        })


### PR DESCRIPTION
Hey guys,

when I try to record a marker I get an SWFResponseError:

```
SWFResponseError: SWFResponseError: 400 Bad Request
{'message': "1 validation error detected: Value null at 'decisions.1.member.recordMarkerDecisionAttributes.markerName' failed to satisfy constraint: Member must not be null", '__type': 'com.amazon.coral.validate#ValidationException'}
```

I already fixed it.

regards
Hannes
