### PR TITLE
Fix/unknown resource handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ python:
 install: "python setup.py install"
 
 # command to run tests
-script: nosetests
+script: nosetests --with-doctest

--- a/swf/exceptions.py
+++ b/swf/exceptions.py
@@ -5,6 +5,13 @@
 #
 # See the file LICENSE for copying permission.
 
+import logging
+import collections
+from functools import wraps, partial
+import re
+
+import boto.swf.exceptions
+
 
 class SWFError(Exception):
     def __init__(self, message, raw_error='', *args, **kwargs):
@@ -98,3 +105,290 @@ class AlreadyExistsError(SWFError):
 
 class InvalidKeywordArgumentError(SWFError):
     pass
+
+
+def ignore(*args, **kwargs):
+    return
+
+
+REGEX_UNKNOWN_RESOURCE = re.compile(r'^[^ ]+\s+([^ :]+)')
+REGEX_NESTED_RESOURCE = re.compile(r'Unknown (?:type|execution):\s*([^=]+)=\[')
+
+
+def match_equals(regex, string, values):
+    """
+    Extract a value from a string with a regex and compare it.
+
+    :param regex: to extract the value to check.
+    :type  regex: _sre.SRE_Pattern (compiled regex)
+
+    :param string: that contains the value to extract.
+    :type  string: str
+
+    :param values: to compare with.
+    :type  values: [str]
+
+    """
+    if string is None:
+        return False
+
+    matched = regex.findall(string)
+    if not matched:
+        return False
+
+    if (isinstance(values, basestring) and
+        not isinstance(values, collections.Sequence)):
+        values = (values,)
+    return matched[0] in values
+
+
+def is_swf_response_error(error):
+    """
+    Return true if *error* is a :class:`SWFResponseError` exception.
+
+    :param error: is the exception to check.
+    :type  error: Exception.
+
+    """
+    return isinstance(error, boto.swf.exceptions.SWFResponseError)
+
+
+def is_unknown_resource_raised(error, *args, **kwargs):
+    """
+    Handler that checks if *error* is an unknown resource fault.
+
+    :param error: is the exception to check.
+    :type  error: Exception
+
+    """
+    if not isinstance(error, boto.swf.exceptions.SWFResponseError):
+        return False
+
+    return getattr(error, 'error_code', None) == 'UnknownResourceFault'
+
+
+def is_unknown(resource):
+    """
+    Return a function that checks if *error* is an unknown *resource* fault.
+
+    """
+    @wraps(is_unknown)
+    def wrapped(error, *args, **kwargs):
+        """
+        :param error: is the exception to check.
+        :type  error: Exception
+
+        """
+        if not is_unknown_resource_raised(error, *args, **kwargs):
+            return False
+        if getattr(error, 'error_code', None) != 'UnknownResourceFault':
+            raise ValueError('cannot extract resource from {}'.format(
+                             error))
+
+        message = error.body.get('message')
+        if match_equals(REGEX_UNKNOWN_RESOURCE,
+                        message,
+                        ('type', 'execution')):
+            return match_equals(REGEX_NESTED_RESOURCE, message, resource)
+        return match_equals(REGEX_UNKNOWN_RESOURCE, message, resource)
+
+    return wrapped
+
+
+def always(value):
+    """
+    Always return *value* whatever arguments it got.
+
+    Examples
+    --------
+
+    >>> f = always(1)
+    >>> f('a', 'b')
+    1
+
+    >>> f = always(lambda: True)
+    >>> f('foo')
+    True
+
+    """
+    import types
+
+    @wraps(always)
+    def wrapped(*args, **kwargs):
+        if isinstance(value, types.FunctionType):
+            return value()
+        return value
+    return wrapped
+
+
+def extract_resource(error):
+    if getattr(error, 'error_code', None) != 'UnknownResourceFault':
+        raise ValueError('cannot extract resource from {}'.format(
+                         error))
+
+    message = error.body.get('message')
+    resource = (REGEX_UNKNOWN_RESOURCE.findall(message) if
+                message else None)
+    return "Resource {} does not exist".format(
+           resource[0] if resource else 'unknown')
+
+
+def raises(exception, when, extract=str):
+    """
+    :param exception: to raise when the predicate is True.
+    :type  exception: Exception
+
+    :param when: predicate to apply.
+    :type  when: (error, *args, **kwargs) -> bool
+
+    Examples
+    --------
+
+    Let's build a :class:`boto.swf.exceptions.SWFResponseError` for an unknown
+    execution:
+
+    >>> status = 400
+    >>> reason = 'Bad Request'
+    >>> body_type = 'com.amazonaws.swf.base.model#UnknownResourceFault'
+    >>> body_message = 'Unknown execution: blah'
+    >>> body = {'__type': body_type, 'message': body_message}
+    >>> error_code = 'UnknownResourceFault'
+    >>> from boto.swf.exceptions import SWFResponseError
+    >>> err = SWFResponseError(status, reason, body, error_code)
+    >>> raises(DoesNotExistError,
+    ...        when=is_unknown_resource_raised,
+    ...        extract=extract_resource)(err)
+    Traceback (most recent call last):
+        ...
+    DoesNotExistError: Resource execution does not exist
+
+    >>> body = {'__type': body_type}
+    >>> err = SWFResponseError(status, reason, body, error_code)
+    >>> raises(DoesNotExistError,
+    ...        when=is_unknown_resource_raised,
+    ...        extract=extract_resource)(err)
+    Traceback (most recent call last):
+        ...
+    DoesNotExistError: Resource unknown does not exist
+
+    Now, we do the same for an unknown domain:
+
+    >>> body_message = 'Unknown domain'
+    >>> body = {'__type': body_type, 'message': body_message}
+    >>> err = SWFResponseError(status, reason, body, error_code)
+    >>> raises(DoesNotExistError,
+    ...        when=is_unknown_resource_raised,
+    ...        extract=extract_resource)(err)
+    Traceback (most recent call last):
+        ...
+    DoesNotExistError: Resource domain does not exist
+
+    If it does not detect an error related to an unknown resource,
+    it raises a :class:`ResponseError`:
+
+    >>> body_message = 'Other Fault'
+    >>> body = {'__type': body_type, 'message': body_message}
+    >>> err = SWFResponseError(status, reason, body, error_code)
+    >>> err.error_code = 'OtherFault'
+    >>> raises(DoesNotExistError,
+    ...        when=is_unknown_resource_raised,
+    ...        extract=extract_resource)(err)
+    Traceback (most recent call last):
+        ...
+    SWFResponseError: SWFResponseError: 400 Bad Request
+    {'message': 'Other Fault', '__type': 'com.amazonaws.swf.base.model#UnknownResourceFault'}
+
+    If it's not a :class:`boto.swf.exceptions.SWFResponseError`, it
+    raises the exception as-is:
+
+    >>> raises(DoesNotExistError,
+    ...        when=is_unknown_resource_raised,
+    ...        extract=extract_resource)(Exception('boom!'))
+    Traceback (most recent call last):
+        ...
+    Exception: boom!
+
+    """
+    @wraps(raises)
+    def raises_closure(error, *args, **kwargs):
+        if when(error, *args, **kwargs) is True:
+            raise exception(extract(error))
+        raise error
+    return raises_closure
+
+
+def catch(exceptions, handle_with=None, log=False):
+    """
+    Catch *exceptions*, then eventually handle and log them.
+
+    :param exceptions: sequence of exceptions to catch.
+    :type  exceptions: tuple
+
+    :param handle_with: handle the exceptions (if handle_with is not None) or
+                        raise them again.
+    :type  handle_with: function(err, *args, **kwargs)
+
+    :param log: the exception with default logger.
+    :type  log: bool
+
+    Examples:
+
+    >>> def boom():
+    ...     raise ValueError('test')
+    >>> func = catch(ValueError)(boom)
+    >>> func()
+    Traceback (most recent call last):
+        ...
+    ValueError: test
+    >>> func = catch(ValueError, handle_with=ignore)(boom)
+    >>> func()
+    >>> func = catch([ValueError], handle_with=ignore)(boom)
+    >>> func()
+
+    """
+    def wrap(func):
+        @wraps(func)
+        def decorated(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except exceptions as err:
+                if log is True:
+                    logger = logging.getLogger(__name__)
+
+                    logger.error('call to {} raised: {}'.format(
+                                 func.__name__,
+                                 err))
+
+                if handle_with is None:
+                    raise
+
+                return handle_with(err, *args, **kwargs)
+
+        return decorated
+
+    if not isinstance(exceptions, collections.Sequence):
+        exceptions = tuple([exceptions])
+    elif not isinstance(exceptions, tuple):
+        exceptions = tuple(exceptions)
+
+    return wrap
+
+
+when = catch
+
+
+is_not = partial(catch, handle_with=always(False))
+is_not.__doc__ = """
+    Return ``False`` if it catches an exception among *exceptions*.
+"""
+
+
+def translate(exceptions, to):
+    """
+    Catches an exception among *exceptions* and raise *to* instead.
+
+    """
+    def throw(err, *args, **kwargs):
+        raise to(err.message)
+
+    return catch(exceptions, handle_with=throw)

--- a/swf/models/history.py
+++ b/swf/models/history.py
@@ -159,13 +159,13 @@ class History(object):
 
         .. code-block:: python
 
-            >>> history_obj.filter(type='ActivityTask', state='completed')
+            >>> history_obj.filter(type='ActivityTask', state='completed')  # doctest: +SKIP
             <History
                 <Event 23 ActivityTask : completed>
                 <Event 42 ActivityTask : completed>
                 <Event 61 ActivityTask : completed>
             >
-            >>> history_obj.filter(type='DecisionTask')
+            >>> history_obj.filter(type='DecisionTask')  # doctest: +SKIP
             <History
                 <Event 2 DecisionTask : scheduled>
                 <Event 3 DecisionTask : started>

--- a/swf/utils.py
+++ b/swf/utils.py
@@ -22,23 +22,26 @@ datetime_timestamp = lambda datetime: mktime(datetime.timetuple())
 
 
 class Enum(object):
-    """Enums python implementation
+    """Enumeration type
 
-    To be used like this :
-        Numbers = enum('ZERO', 'ONE', 'TWO')
-        >>> Numbers.ZERO
-        0
-        >>> Numbers.ONE
-        1
+    Examples
+    --------
 
-        or
+    >>> Numbers = Enum('ZERO', 'ONE', 'TWO')
+    >>> Numbers.ZERO
+    0
+    >>> Numbers.ONE
+    1
 
-        Numbers = enum(zero="ZERO", one="ONE")
-        >>> Numbers.zero
-        "ZERO"
+    or
+
+    >>> Numbers = Enum(zero="ZERO", one="ONE")
+    >>> Numbers.zero
+    'ZERO'
 
     Inspired from:
     http://stackoverflow.com/questions/36932/whats-the-best-way-to-implement-an-enum-in-python
+
     """
     def __init__(self, *sequential, **named):
         self.enums = dict(zip(sequential, range(len(sequential))), **named)
@@ -57,25 +60,27 @@ def get_subkey(d, key_path):
     """Gets a sub-dict key, and return None if whether
     the parent or child dict key does not exist
 
-    Example:
-    >>> d = {
-      'a': {
-        '1': 2,
-        '2': 3,
-      }
-    }
-    >>> subkey(d, ['a'])
-    {'1': 2, '2': 3}
-    >>> subkey(d, ['a', '1'])
-    2
-    >>> subkey(d, ['a', '3'])
-    None
-
     :param  d: dict to operate over
     :type   d: dict of dicts
 
     :param  key_path: dict keys path list representation
     :type   key_path: list
+
+    Example
+    -------
+
+    >>> d = {
+    ...   'a': {
+    ...     '1': 2,
+    ...     '2': 3,
+    ...   }
+    ... }
+    >>> get_subkey(d, ['a'])
+    {'1': 2, '2': 3}
+    >>> get_subkey(d, ['a', '1'])
+    2
+    >>> get_subkey(d, ['a', '3'])
+
     """
     if len(key_path) > 1:
         if d.get(key_path[0]) is None:

--- a/tests/models/test_workflow.py
+++ b/tests/models/test_workflow.py
@@ -87,9 +87,12 @@ class TestWorkflowType(unittest2.TestCase):
         with patch.object(self.wt.connection, 'describe_workflow_type') as mock:
             mock.side_effect = SWFResponseError(
                     400,
-                    "mocking exception",
-                    {'__type': 'UnknownResourceFault'}
-            )
+                    "Bad Request:",
+                    {'__type': 'com.amazonaws.swf.base.model#UnknownResourceFault',
+                     'message': 'Unknown type: WorkflowType=[workflowId=blah, runId=test]'},
+                    'UnknownResourceFault',
+                )
+
             self.assertFalse(self.wt.exists)
 
     def test_workflow_type_exists_with_whatever_error(self):
@@ -293,9 +296,12 @@ class TestWorkflowExecution(unittest2.TestCase):
         with patch.object(self.we.connection, 'describe_workflow_execution') as mock:
             mock.side_effect = SWFResponseError(
                     400,
-                    "mocking exception",
-                    {'__type': 'UnknownResourceFault'}
-            )
+                    "Bad Request:",
+                    {'__type': 'com.amazonaws.swf.base.model#UnknownResourceFault',
+                     'message': 'Unknown execution: WorkflowExecution=[workflowId=blah, runId=test]'},
+                    'UnknownResourceFault',
+                )
+
             self.assertFalse(self.we.exists)
 
     def test_workflow_execution_exists_with_whatever_error(self):


### PR DESCRIPTION
Fix #35
- Add decorators in `swf.exceptions`:
  - `@catch` (also aliased as `when`),
  - `@translate`
  - `@is_not`
- Add specific exceptions in `swf.models` modules `domain`, `activity`, `workflow`.
- Wrap model methods with `@when`, `@is_not`, and `@translate` to hide the plumbing and group it in the same place.
- Fix tests (unit and doctests).
- Enable doctest in travis.

I chose to decorate methods instead of patching the `boto.swf.connection` methods to avoid messing with mocking and having an implicit behaviour.
