### PR TITLE
Always accept region from env

### DIFF
--- a/swf/settings.py
+++ b/swf/settings.py
@@ -105,13 +105,16 @@ def from_env():
     :rtype: dict
 
     """
-    try:
-        return {'aws_access_key_id': os.environ['AWS_ACCESS_KEY_ID'],
-                'aws_secret_access_key': os.environ.get('AWS_SECRET_ACCESS_KEY'),
-                'region': os.environ.get('AWS_DEFAULT_REGION')
-        }
-    except KeyError:
-        return {}
+    hsh = {}
+
+    if "AWS_ACCESS_KEY_ID" in os.environ:
+        hsh["aws_access_key_id"] = os.environ["AWS_ACCESS_KEY_ID"]
+        hsh["aws_secret_access_key"] = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+    if "AWS_DEFAULT_REGION" in os.environ:
+        hsh["region"] = os.environ["AWS_DEFAULT_REGION"]
+
+    return hsh
 
 
 def get(path='.swf'):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,11 +37,13 @@ class TestSettings(unittest.TestCase):
             "region": "eu-west-1",
         })
 
-    # TODO: change that, this is weird and confuses me as for AWS_DEFAULT_REGION handling
     def test_get_aws_settings_without_access_key_id(self):
         """
-        If AWS_DEFAULT_REGION is not set, don't get anything from env.
+        If AWS_DEFAULT_REGION is not set, get AWS_DEFAULT_REGION from env anyway if there.
         """
+        self.assertEqual(from_env(), {})
+
         os.environ["AWS_DEFAULT_REGION"] = "eu-west-1"
-        _settings = from_env()
-        self.assertEqual(_settings, {})
+        self.assertEqual(from_env(), {
+            "region": "eu-west-1",
+        })

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+
+from swf.settings import from_env
+
+AWS_ENV_KEYS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_DEFAULT_REGION",
+)
+
+class TestSettings(unittest.TestCase):
+    def setUp(self):
+        self.oldies = {}
+        for key in AWS_ENV_KEYS:
+            self.oldies[key] = os.environ.get(key)
+            os.environ.pop(key, None)
+
+    def tearDown(self):
+        for key in AWS_ENV_KEYS:
+            if self.oldies[key]:
+                os.environ[key] = self.oldies[key]
+            else:
+                os.environ.pop(key, None)
+
+    def test_get_aws_settings_with_access_key_id(self):
+        """
+        If AWS_ACCESS_KEY_ID is set, get all 3 params from env.
+        """
+        os.environ["AWS_ACCESS_KEY_ID"] = "foo"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "bar"
+        os.environ["AWS_DEFAULT_REGION"] = "eu-west-1"
+        _settings = from_env()
+        self.assertEqual(_settings, {
+            "aws_access_key_id": "foo",
+            "aws_secret_access_key": "bar",
+            "region": "eu-west-1",
+        })
+
+    # TODO: change that, this is weird and confuses me as for AWS_DEFAULT_REGION handling
+    def test_get_aws_settings_without_access_key_id(self):
+        """
+        If AWS_DEFAULT_REGION is not set, don't get anything from env.
+        """
+        os.environ["AWS_DEFAULT_REGION"] = "eu-west-1"
+        _settings = from_env()
+        self.assertEqual(_settings, {})


### PR DESCRIPTION
Took me a bit to figure it out, but as of today the region passed from environment is not respected if credentials are not passed from env. This is confusing and wrong I think, so here's a PR to change that.

poke @ybastide 