### PR TITLE
Allow close time filters in WorkflowExecutionQueryset.filter()

### DIFF
--- a/tests/querysets/test_workflow.py
+++ b/tests/querysets/test_workflow.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from mock import patch
+from mock import patch, Mock
 from boto.swf.layer1 import Layer1
 from boto.exception import SWFResponseError
 
@@ -317,3 +317,19 @@ class TestWorkflowExecutionQuerySet(unittest.TestCase):
                     }
                 )
                 self.weq.get("mocked-workflow-id", "mocked-run-id")
+
+    def test_filter_without_close_time_filter(self):
+        self.weq._list_items = Mock(return_value=[])
+        qs = self.weq.filter()
+        self.weq._list_items.assert_called_once()
+        kwargs = self.weq._list_items.call_args[1]
+        self.assertIsInstance(kwargs["start_oldest_date"], int)
+
+    def test_filter_with_close_time_filter(self):
+        self.weq._list_items = Mock(return_value=[])
+        qs = self.weq.filter(status=WorkflowExecution.STATUS_CLOSED,
+                             close_latest_date=5)
+        self.weq._list_items.assert_called_once()
+        kwargs = self.weq._list_items.call_args[1]
+        self.assertIsNone(kwargs["start_oldest_date"])
+        self.assertIsInstance(kwargs["close_latest_date"], int)


### PR DESCRIPTION
The current code introduces a start time filter if absent, which is
incompatible with a close time filter per the API docs. So we have to be
smarter and only introduce a default start time filter if no close time
filter is passed.

SWF docs: http://docs.aws.amazon.com/amazonswf/latest/apireference/API_ListClosedWorkflowExecutions.html#SWF-ListClosedWorkflowExecutions-request-startTimeFilter

---

Note that it doesn't prevent incompatible parameters in the input, but the previous code didn't either. It just makes _possible_ to use close time filters, while it was previously broken (we received an error from SWF API stating that parameters were incompatible).

ping @ybastide 
